### PR TITLE
BZ-1221380: remove use of cookies (that have 4k limit) what, depending

### DIFF
--- a/livespark-webapp/src/main/resources/ErraiApp.properties
+++ b/livespark-webapp/src/main/resources/ErraiApp.properties
@@ -13,3 +13,4 @@
 # file, although it is rarely necessary. See the documentation at
 # https://docs.jboss.org/author/display/ERRAI/ErraiApp.properties
 # for details.
+errai.security.user_on_hostpage_enabled=true


### PR DESCRIPTION
of the number of roles/groups of a user, can be reached. new solution
`patches` the host page (UserHostPageFilter) with user's info that now
is supported on errai client security.