### PR TITLE
Fix issues with boolean column generation and issue with build service cleanup.

### DIFF
--- a/livespark-common-widgets/livespark-crud-component/pom.xml
+++ b/livespark-common-widgets/livespark-crud-component/pom.xml
@@ -46,6 +46,10 @@
       <artifactId>errai-data-binding</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.jboss.errai</groupId>
+      <artifactId>errai-ui</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.uberfire</groupId>
       <artifactId>uberfire-widgets-table</artifactId>
     </dependency>

--- a/livespark-deployment/src/main/java/org/livespark/backend/server/service/build/BuildAndDeployCallable.java
+++ b/livespark-deployment/src/main/java/org/livespark/backend/server/service/build/BuildAndDeployCallable.java
@@ -141,13 +141,18 @@ public class BuildAndDeployCallable extends BaseBuildCallable implements HttpSes
     }
 
     private File getTargetDir() {
-        final File targetDir = new File( pomXml.getParent(), "/target" );
+        final File targetDir = new File( pomXml.getParent(), "target" );
         return targetDir;
     }
 
     private Collection<File> getWarFiles( ) {
-        final Collection<File> wars = FileUtils.listFiles( getTargetDir(), new String[]{"war"}, false );
-        return wars;
+        final File targetDir = getTargetDir();
+        if (targetDir.exists()) {
+            return FileUtils.listFiles( targetDir, new String[]{"war"}, false );
+        }
+        else {
+            return Collections.emptyList();
+        }
     }
 
     private File getDeployDir() throws MalformedURLException,

--- a/livespark-form-modeler/livespark-form-modeler-codegen/livespark-form-modeler-codegen-impl/src/main/java/org/livespark/formmodeler/codegen/view/impl/java/tableColumns/impl/BooleanBasicTypeColumnMetaGenerator.java
+++ b/livespark-form-modeler/livespark-form-modeler-codegen/livespark-form-modeler-codegen-impl/src/main/java/org/livespark/formmodeler/codegen/view/impl/java/tableColumns/impl/BooleanBasicTypeColumnMetaGenerator.java
@@ -21,7 +21,7 @@ import org.livespark.formmodeler.codegen.SourceGenerationContext;
 
 import static org.livespark.formmodeler.codegen.util.SourceGenerationUtil.*;
 
-public abstract class BooleanBasicTypeColumnMetaGenerator extends AbstractColumnMetaGenerator {
+public class BooleanBasicTypeColumnMetaGenerator extends AbstractColumnMetaGenerator {
 
     public static final String CHECKBOX_COLUMN_SUFFIX = COLUMN_META_SUFFIX + "_checkbox";
 

--- a/livespark-form-modeler/livespark-form-modeler-codegen/livespark-form-modeler-codegen-impl/src/main/java/org/livespark/formmodeler/codegen/view/impl/java/tableColumns/impl/BooleanBasicTypeColumnMetaGenerator.java
+++ b/livespark-form-modeler/livespark-form-modeler-codegen/livespark-form-modeler-codegen-impl/src/main/java/org/livespark/formmodeler/codegen/view/impl/java/tableColumns/impl/BooleanBasicTypeColumnMetaGenerator.java
@@ -60,7 +60,7 @@ public class BooleanBasicTypeColumnMetaGenerator extends AbstractColumnMetaGener
     public String[] getImports() {
         return new String[]{
             "com.google.gwt.user.cellview.client.Column",
-            "org.uberfire.ext.widgets.common.client.common.CheckboxCellImpl"
+            "org.uberfire.ext.widgets.table.client.CheckboxCellImpl"
         };
     }
 }

--- a/livespark-form-modeler/livespark-form-modeler-codegen/livespark-form-modeler-codegen-impl/src/main/java/org/livespark/formmodeler/codegen/view/impl/java/tableColumns/impl/BooleanColumnMetaGenerator.java
+++ b/livespark-form-modeler/livespark-form-modeler-codegen/livespark-form-modeler-codegen-impl/src/main/java/org/livespark/formmodeler/codegen/view/impl/java/tableColumns/impl/BooleanColumnMetaGenerator.java
@@ -21,7 +21,7 @@ import org.livespark.formmodeler.codegen.SourceGenerationContext;
 
 import static org.livespark.formmodeler.codegen.util.SourceGenerationUtil.*;
 
-public abstract class BooleanColumnMetaGenerator extends AbstractColumnMetaGenerator {
+public class BooleanColumnMetaGenerator extends AbstractColumnMetaGenerator {
 
     public static final String CHECKBOX_COLUMN_SUFFIX = COLUMN_META_SUFFIX + "_checkbox";
 
@@ -38,7 +38,7 @@ public abstract class BooleanColumnMetaGenerator extends AbstractColumnMetaGener
                 .append( "public Boolean getValue( " )
                 .append( modelTypeName )
                 .append( " model ) {" )
-                .append( "Boolean value = model.get" )
+                .append( "Boolean value = model.is" )
                 .append( StringUtils.capitalize( property ) )
                 .append( "();" )
                 .append( "if ( value == null ) { return Boolean.FALSE; }" )

--- a/livespark-form-modeler/livespark-form-modeler-dynamic-renderer/livespark-form-modeler-dynamic-renderer-client/src/main/java/org/livespark/formmodeler/renderer/client/rendering/renderers/relations/multipleSubform/columns/impl/BooleanColumnGenerator.java
+++ b/livespark-form-modeler/livespark-form-modeler-dynamic-renderer/livespark-form-modeler-dynamic-renderer-client/src/main/java/org/livespark/formmodeler/renderer/client/rendering/renderers/relations/multipleSubform/columns/impl/BooleanColumnGenerator.java
@@ -18,10 +18,11 @@ package org.livespark.formmodeler.renderer.client.rendering.renderers.relations.
 
 import javax.enterprise.context.Dependent;
 
-import com.google.gwt.user.cellview.client.Column;
 import org.jboss.errai.databinding.client.HasProperties;
 import org.livespark.formmodeler.renderer.client.rendering.renderers.relations.multipleSubform.columns.ColumnGenerator;
-import org.uberfire.ext.widgets.common.client.common.CheckboxCellImpl;
+import org.uberfire.ext.widgets.table.client.CheckboxCellImpl;
+
+import com.google.gwt.user.cellview.client.Column;
 
 @Dependent
 public class BooleanColumnGenerator implements ColumnGenerator<Boolean> {

--- a/livespark-integration-tests/src/test/java/org/livespark/codegen/DataModelGenerationTest.java
+++ b/livespark-integration-tests/src/test/java/org/livespark/codegen/DataModelGenerationTest.java
@@ -78,7 +78,7 @@ public class DataModelGenerationTest extends BaseIntegrationTest {
         assertViewProperty( bindNamePrefix + "_numOfFans", clazz );
         assertViewProperty( bindNamePrefix + "_iq", clazz );
         assertViewProperty( bindNamePrefix + "_favLetter", clazz );
-        assertViewProperty( bindNamePrefix + "_isPopular", clazz );
+        assertViewProperty( bindNamePrefix + "_popular", clazz );
         assertViewProperty( bindNamePrefix + "_height", clazz );
         assertViewProperty( bindNamePrefix + "_weight", clazz );
         assertViewProperty( bindNamePrefix + "_numOfGuitars", clazz );
@@ -94,7 +94,7 @@ public class DataModelGenerationTest extends BaseIntegrationTest {
         dataObject.addProperty( "numOfFans", BigInteger.class.getCanonicalName() );
         dataObject.addProperty( "iq", Byte.class.getCanonicalName() );
         dataObject.addProperty( "favLetter", char.class.getCanonicalName() );
-        dataObject.addProperty( "isPopular", boolean.class.getCanonicalName() );
+        dataObject.addProperty( "popular", boolean.class.getCanonicalName() );
         dataObject.addProperty( "height", double.class.getCanonicalName() );
         dataObject.addProperty( "weight", float.class.getCanonicalName() );
         dataObject.addProperty( "numOfGuitars", long.class.getCanonicalName() );


### PR DESCRIPTION
This PR depends on two PRs in [uberfire-extensions](https://github.com/uberfire/uberfire-extensions/pull/274) and [kie-wb-common](https://github.com/droolsjbpm/kie-wb-common/pull/348).

This PR:
* Uses the "is" prefix for getters of boolean values.
* Uses the new fully qualified name of CheckboxCellImpl (moved in linked PRs).
* Fixes exception when session expires and target directory is deleted before the deployed war file.
* Adds errai-ui as a dependency (no longer brought in transitively).