### PR TITLE
Fixes to integration-test harness + fix a double-deployment bug

### DIFF
--- a/livespark-deployment/src/main/java/org/livespark/backend/server/service/GwtWarBuildServiceImpl.java
+++ b/livespark-deployment/src/main/java/org/livespark/backend/server/service/GwtWarBuildServiceImpl.java
@@ -208,23 +208,17 @@ public class GwtWarBuildServiceImpl extends BuildServiceImpl implements GwtWarBu
 
     @Override
     public BuildResults buildAndDeploy( Project project ) {
-        BuildResults results = super.buildAndDeploy( project );
-        deployWar( project );
-        return results;
+        return buildAndDeploy( project, false, DeploymentMode.VALIDATED );
     }
 
     @Override
     public BuildResults buildAndDeploy( Project project, DeploymentMode mode ) {
-        BuildResults results = super.buildAndDeploy( project, mode );
-        deployWar( project );
-        return results;
+        return buildAndDeploy( project, false, mode );
     }
 
     @Override
     public BuildResults buildAndDeploy( Project project, boolean suppressHandlers ) {
-        BuildResults results =  super.buildAndDeploy( project, suppressHandlers );
-        deployWar( project );
-        return results;
+        return buildAndDeploy( project, suppressHandlers, DeploymentMode.VALIDATED );
     }
 
     @Override

--- a/livespark-deployment/src/main/java/org/livespark/backend/server/service/build/BaseBuildCallable.java
+++ b/livespark-deployment/src/main/java/org/livespark/backend/server/service/build/BaseBuildCallable.java
@@ -22,6 +22,7 @@ import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 
 import javax.servlet.ServletContext;
 import javax.servlet.ServletRequest;
@@ -44,6 +45,7 @@ public abstract class BaseBuildCallable implements BuildCallable {
     private static final Logger logger = LoggerFactory.getLogger( BaseBuildCallable.class );
     private static final String LOG_BUILD_OUTPUT_PROPERTY = "livespark.log_build_output";
     private static final boolean logBuildOutput = Boolean.valueOf( System.getProperty( LOG_BUILD_OUTPUT_PROPERTY, "false" ) );
+    private static final Optional<String> ALT_LOCAL_MVN_REPO = Optional.ofNullable( System.getProperty( "maven.repo.local" ) );
 
     protected final Project project;
     protected final File pomXml;
@@ -142,8 +144,16 @@ public abstract class BaseBuildCallable implements BuildCallable {
 
         packageRequest.setPomFile( pomXml );
         packageRequest.setGoals( Collections.singletonList( "package" ) );
+        maybeSetLocalRepo( packageRequest );
 
         return packageRequest;
+    }
+
+    protected void maybeSetLocalRepo( final DefaultInvocationRequest request ) {
+        ALT_LOCAL_MVN_REPO
+            .filter( path -> !path.isEmpty() )
+            .map( path -> new File(path) )
+            .ifPresent( repo -> request.setLocalRepositoryDirectory( repo ) );
     }
 
     private void cleanClientConsole() {

--- a/livespark-deployment/src/main/java/org/livespark/backend/server/service/build/BuildAndDeployWithCodeServerCallable.java
+++ b/livespark-deployment/src/main/java/org/livespark/backend/server/service/build/BuildAndDeployWithCodeServerCallable.java
@@ -94,6 +94,7 @@ public class BuildAndDeployWithCodeServerCallable extends BuildAndDeployCallable
         codeServerRequest.setPomFile( pomXml );
         codeServerRequest.setGoals( Collections.singletonList( "gwt:run-codeserver" ) );
         codeServerRequest.setProperties( codeServerProperties );
+        maybeSetLocalRepo( codeServerRequest );
 
         return codeServerRequest;
     }
@@ -107,6 +108,7 @@ public class BuildAndDeployWithCodeServerCallable extends BuildAndDeployCallable
         packageRequest.setPomFile( pomXml );
         packageRequest.setGoals( Collections.singletonList( "package" ) );
         packageRequest.setProperties( props );
+        maybeSetLocalRepo( packageRequest );
 
         return packageRequest;
     }

--- a/livespark-integration-tests/pom.xml
+++ b/livespark-integration-tests/pom.xml
@@ -199,6 +199,14 @@
           </filesets>
         </configuration>
       </plugin>
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <systemPropertyVariables>
+            <maven.repo.local>${maven.repo.local}</maven.repo.local>
+          </systemPropertyVariables>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
   

--- a/livespark-integration-tests/src/test/resources/arquillian.xml
+++ b/livespark-integration-tests/src/test/resources/arquillian.xml
@@ -11,7 +11,7 @@
   <configuration>  
       <property name="jbossHome">target/wildfly-8.1.0.Final</property>  
       <!-- Uberfire daemons must be turned off or else repeated deployments will fail to bind to addresses. -->
-      <property name="javaVmArguments">-Xmx1g -XX:MaxPermSize=512m -Xrunjdwp:transport=dt_socket,address=8086,server=y,suspend=n -Dorg.uberfire.nio.git.daemon.enabled=false -Dorg.uberfire.nio.git.ssh.enabled=false -Dlivespark.log_build_output=true</property>
+      <property name="javaVmArguments">-Xmx1g -XX:MaxPermSize=512m -Xrunjdwp:transport=dt_socket,address=8086,server=y,suspend=n -Dorg.uberfire.nio.git.daemon.enabled=false -Dorg.uberfire.nio.git.ssh.enabled=false -Dlivespark.log_build_output=true -Dmaven.repo.local=${maven.repo.local}</property>
       <property name="allowConnectingToRunningServer">true</property>  
     </configuration>  
   </container>  


### PR DESCRIPTION
The generated app will now be built using the local maven repository set by
the system property "maven.repo.local".

The integration tests are now configured to build the generated app
with the same maven local repo as the integration tests use themselves.

Avoid calling buildAndDeploy multiple times by only dispatching to
the super class a single time. This caused integration tests to intermittently fail
from the generated war file being deployed multiple times.