### PR TITLE
LiveSparkEntryPointTest test fix

### DIFF
--- a/livespark-showcase/livespark-webapp/src/test/java/org/livespark/client/LiveSparkEntryPointTest.java
+++ b/livespark-showcase/livespark-webapp/src/test/java/org/livespark/client/LiveSparkEntryPointTest.java
@@ -142,12 +142,6 @@ public class LiveSparkEntryPointTest {
         liveSparkEntryPoint.init();
 
         verify( workbench ).addStartupBlocker( LiveSparkEntryPoint.class );
-    }
-
-    @Test
-    public void startDefaultWorkbenchWithCustomSecurityLoadedCallbackTest() {
-        liveSparkEntryPoint.startDefaultWorkbench();
-
         verify( homeProducer ).init();
     }
 


### PR DESCRIPTION
Call to homeProducer.init(); is made by liveSparkEntryPoint.init(); now.